### PR TITLE
Fix duplicate segment in qualified name after adapter FB refactor

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/AdapterDeclarationAnnotations.java
+++ b/plugins/org.eclipse.fordiac.ide.model/src/org/eclipse/fordiac/ide/model/libraryElement/impl/AdapterDeclarationAnnotations.java
@@ -22,7 +22,7 @@ import org.eclipse.fordiac.ide.model.libraryElement.INamedElement;
 public final class AdapterDeclarationAnnotations {
 
 	static Stream<INamedElement> findBySimpleName(final AdapterDeclaration root, final String name) {
-		final AdapterFB adapterFB = root.getAdapterFB();
+		final AdapterFB adapterFB = root.getInterfaceOnlyAdapterFB();
 		if (adapterFB != null) {
 			return Stream.concat(NamedElementAnnotations.findBySimpleName(root, name)
 					.filter(Predicate.not(AdapterFB.class::isInstance)), adapterFB.findBySimpleName(name));


### PR DESCRIPTION
This is necessary, since the containment reference is now the interface-only adapter FB, for which we need to perform the name lookup directly in the adapter FB to skip a duplicate name segment.